### PR TITLE
Improvements to Filter Highlights by Tag, Update Tags on Server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,35 +145,45 @@ The `rw-inbox-view` accepts an optional parameter, a `dv.pages` object. This obj
 
 The following example return just tweets:
 
+~~~
 ```dataviewjs
 const tweets = dv.pages('"Readwise/tweets"')
 dv.view("rw-inbox-view", tweets );
 ```
+~~~
 
 All Twitter highlights from this year:
 
+~~~
 ```dataviewjs
 const tweets = dv.pages('"Readwise/tweets"').filter(p=>new Date(p.created)>new Date("2022-01-01"))
 dv.view("rw-inbox-view", tweets );
 ```
+~~~
 
 Highlights that have been tagged with `#priority`, and from the Readwise export folder
 
+~~~
 ```dataviewjs
 const byTags = dv.pages("#priority and \"30-Files/99-ReadwiseSync\"")
 dv.view("rw-inbox-view", byTags );
 ```
+~~~
 
 Highlights that have been tagged with `#priority` or `#important`, and from the Readwise export folder
 
+~~~
 ```dataviewjs
 const byTags = dv.pages("(#priority or #important) and \"30-Files/99-ReadwiseSync\"")
 dv.view("rw-inbox-view", byTags );
 ```
+~~~
 
 Return all highlights with the frontmatter source value equal to a specific author:
 
+~~~
 ```dataviewjs
 const byAuthor = dv.pages('"30-Files/99-ReadwiseSync"').where(p=>p.file.frontmatter?.author=='nickwignall.com')
 dv.view("rw-inbox-view", byAuthor);
 ```
+~~~

--- a/readme.md
+++ b/readme.md
@@ -1,47 +1,95 @@
-# Warning
+# Readwise Inbox for Obsidian
+
+## Warning
+
 This solution is intended for users who are comfortable hacking around Obsidian and don't mind reading documentation. I assume you have a basic knowledge of the Readwise Plugin, Dataview Plugin and how block references work in Obsidian.
 
 If you don't know these things or are not prepared to do some reading to learn them, then this solution is not for you.
 
 Please feel free to contact me on twitter if you have questions, but please make sure you have read this document thoroughly. If you respect my time, I will respect yours.
 
-# Introduction
+## Introduction
+
 The Readwise Inbox tool provides an inbox of highlights that need to be processed. Processing depends on your workflow, but mine works like this:
-- Highlights are imported via the [Readwise plugin](https://github.com/readwiseio/obsidian-readwise). I never edit the files imported by Readwise directly. This way if my highlights are exported, my personal notes linked to them are never broken.
-- In another note that I create in my vault, I make notes on the imported highlights. I do not edit the export file. If I want to refer to contents of a highlight, I block reference it. For more info on block references, see this link to [Links to Block](https://help.obsidian.md/How+to/Link+to+blocks) in the Obsidian online help.
+
+- Highlights are imported via the [Readwise plugin](https://github.com/readwiseio/obsidian-readwise). 
+    - I never edit the files imported by Readwise directly. This way if my highlights are exported, my personal notes linked to them are never broken.
+- In another note that I create in my vault, I make notes on the imported highlights. Again, I do not edit the export file. 
+    - If I want to refer to contents of a highlight, I block reference it. For more info on block references, see this link to [Links to Block](https://help.obsidian.md/How+to/Link+to+blocks) in the Obsidian online help.
 - Once I have made my note, I mark the highlight has processed in the Readwise Inbox by clicking on the button with the X in it.
 
-With this tool, you can see an "inbox" of unproccessed highlights from readwise. You process each highlight one at a time. If you click X button, it marks it as complete and disappears from your inbox.
+With this tool, you can see an "inbox" of unproccessed highlights from Readwise. You process each highlight one at a time. If you click X button, it marks it as complete and disappears from your inbox.
 
 You can use the A and T buttons to copy block references to your clipboard. These references are then used in your own personal notes to refer back to the block reference.
 
-## Additional features
-The tool has 3 buttons for each highlight. The following list describes the button
+## Buttons
+The tool has the following buttons for each highlight:
+
 - X - Marks the highlight as processed
 - B - Copies a block reference to the clipboard
 - A - Copies a block reference as an alias with an asterisk to the clipboard
-- T - Copies the text of the higlight and a block reference as an alias with an asterisk to the clipboard
+- T - Copies the text of the highlight and a block reference as an alias with an asterisk to the clipboard
 
 The + sign at the end is a link to the block reference in the file.
 
 ## Additional information
+
 This tool builds on the concept presented in this article [Using Readwise’s highlight_id as a single source of truth in Obsidian](https://tfthacker.medium.com/using-readwises-highlight-id-as-a-single-source-of-truth-in-obsidian-b1de98a8b87c).
 
 This tool assumes that each highlight has an assigned block identifier based on the Readwise highlight identifier.
 
-# Dependencies
+## Dependencies
+
 The following Obsidian plugins are required for this solution:
 - Plugin: Readwise Official Plugin 
   - It is assumed this plugin is configured and the highlights are synced into your vault.
-  - also that you have enabled a unique block identifier for each highlight as mentioned in the "Additional information" section of this readme file.
+  - Also that you have enabled a unique block identifier for each highlight as mentioned in the "Additional information" section of this readme file.
 - Plugin: Dataview
-  - In settings, **Enable JavaScript Queries** needs to be toggled on
+  - In settings, **Enable JavaScript Queries** needs to be toggled on (you might need to reset Obsidian for this to take effect)
 - Plugin: Buttons
 
-# Installation
+## Export Formatting Requirements
+
+This dataview setup expects that each highlight in your export list will have an associated block ID that corresponds to the Readwise highlight ID. You will need to add something like the following to your export in the highlight section:
+
+```jinja2
+^rw{{highlight_id}}
+```
+
+As described the article above, we add a `rw` prefix to the ID so that we can differentiate Readwise IDs from other blocks in the system. You can add any prefix you want (or no prefix), as the code strips out all non-numerical values.
+
+Where you place this block reference matters, since it controls what the dataview query will see. If you want to just see the highlight text, you can place it after the text.
+
+```jinja2
+- {{ highlight_text }} ^rw{{highlight_id}}
+```
+
+However, if you want to use the more advanced capabilities, like tag filtering, you will need to ensure that the placement of the block reference includes any tags. You can do this by including a list of tags following the highlight text, with the block following that. Or, you can place the block reference at the end of an individual list element, which will pull in the whole list item. This will not affect formatting of the exported note - in preview, it will show up as expected.
+
+```jinja2
+- {{ highlight_text }}{% if highlight_tags %} 
+    - Tagged:{% for tag in highlight_tags %} #{{tag|replace(" ","-")}}{% endfor %}{% endif %}
+    - {% if highlight_location and highlight_location_url %}[{{highlight_location}}]({{highlight_location_url}}), {% elif highlight_location %} {{highlight_location}}, {% endif %}[Open in Readwise](https://readwise.io/open/{{highlight_id}}){% if highlight_note %}
+    - Note: {{ highlight_note }}{% endif %}
+^rw{{highlight_id}}
+```
+
+This will export to something like:
+
+```jinja2
+- A sample highlight 
+    - Tagged: #sample-tag #funny
+    - [Page 2](https://readwise.io), [Open in Readwise](https://readwise.io/open/1234)
+^rw1234
+```
+
+This workflow also expects that Readwise tags are exported AS tags (`#tag-name`) instead of as links. We also recommend converting spaces to dashes or underscores, as Obsidian does not allow spaces in tag names.
+
+## Installation
+
 Copy the rw-inbox folder (and all its contents) into your vault. 
 
-With this folder in your vault, open the rw-inbox-viewer.md file. This will display your highlights from the Readwise export folder. 
+With this folder in your vault, open the **rw-inbox-viewer.md** file. This will display your highlights from the Readwise export folder. 
 
 This folder consists of the following:
 - subfolder called **rw-inbox-view**. The files in this folder should not be edited. It is the code used by the Dataview plugin to create the view of our readwise inbox.
@@ -49,8 +97,9 @@ This folder consists of the following:
 - file **rw-inbox-log-processed.md** contains the log of processed highlights. Normally you would not edit this file. It contains the block reference id numbers of processed highlights.
 - file **rw-inbox-viewer.md** is an example of how to use this solution. It contains a dataviewjs query that can be used in any markdown file in your vault. See the next section for more details.
 
-# How to use
-A simple dataviewjs query formatted as follows will retrieve your Readwise highlights:
+## How to use
+
+A simple `dataviewjs` query formatted as follows will retrieve your Readwise highlights:
 
 ~~~
 ```dataviewjs
@@ -58,66 +107,73 @@ dv.view("rw-inbox-view");
 ```
 ~~~
 
-This dataviewjs query can be put into any page. 
+This `dataviewjs` query can be put into any page. 
 
-You can control some aspects of the output of this query by using the following [front matter](https://help.obsidian.md/Advanced+topics/YAML+front+matter):
+You can control some aspects of the output of this query by specifying various configuration keys. The list of supported configuration options is found in` rw-inbox-config.md`. These configuration options specify the defaults for _all_ queries.
 
-- LimitHighlightCount - number of highlights to display
-- SortDateAscending - default sort is date ascending. Set to false for it to sort in descending date order.
+You can also set each configuration value in the [front matter](https://help.obsidian.md/Advanced+topics/YAML+front+matter) of a file or as inline dataview markup. This will override the default setting for that file.
 
-# Querying for specific information
-The rw-inbox-view accepts an optional parameter, a dv.pages object. This object can be used to provide a refined set of pages based on a JavaScript Dataview query. 
+### Filtering Highlights by Tag
+
+If tags are observable through the block reference, you can filter the highlights that are displayed using the `FilterTags` and `FilterTagsToExclude` properties. These can be specified as single values or lists. When used as a list, the `FilterTags` values represent a logical OR - any of the specified tags will be included. Likewise, `FilterTagsToExclude` is a logical NOR - if any of the specified tags are found, the highlight will not be included.
+
+`FilterTags` will cause the view to present only highlights that include the specified tags.
+
+`FilterTagsToExclude` is used to exclude highlights with specific tags. This is useful for when you've already processed something in a separate workflow and want it excluded here, or when you have potential naming collisions that necessitate refined filtering.
+
+```yaml
+---
+FilterTags: anki
+FilterTagsToExclude: [anki-added, processed]
+---
+```
+
+### Processing Tags
+
+You can configure a workflow that will add/remove tags on highlights when you process them with the "X" button. The tags that will be added or removed are specified via configuration options.
+
+```yaml
+---
+OnProcessRemoveTags: [anki]
+OnProcessAddTags: anki-added
+---
+```
+
+### Querying for specific information
+
+The `rw-inbox-view` accepts an optional parameter, a `dv.pages` object. This object can be used to provide a refined set of pages based on a JavaScript Dataview query. 
 
 The following example return just tweets:
 
-~~~
 ```dataviewjs
 const tweets = dv.pages('"Readwise/tweets"')
 dv.view("rw-inbox-view", tweets );
 ```
-~~~
 
 All Twitter highlights from this year:
 
-~~~
 ```dataviewjs
 const tweets = dv.pages('"Readwise/tweets"').filter(p=>new Date(p.created)>new Date("2022-01-01"))
 dv.view("rw-inbox-view", tweets );
 ```
-~~~
 
+Highlights that have been tagged with `#priority`, and from the Readwise export folder
 
-Highlights that have been tagged with #priority, and from the readwise export folder
-
-~~~
 ```dataviewjs
 const byTags = dv.pages("#priority and \"30-Files/99-ReadwiseSync\"")
 dv.view("rw-inbox-view", byTags );
 ```
-~~~
 
-Highlights that have been tagged with #priority or #important, and from the readwise export folder
+Highlights that have been tagged with `#priority` or `#important`, and from the Readwise export folder
 
-~~~
 ```dataviewjs
 const byTags = dv.pages("(#priority or #important) and \"30-Files/99-ReadwiseSync\"")
 dv.view("rw-inbox-view", byTags );
 ```
-~~~
 
-Return all highlights with the frontmatter source value equal to a specific author
+Return all highlights with the frontmatter source value equal to a specific author:
 
-~~~
 ```dataviewjs
 const byAuthor = dv.pages('"30-Files/99-ReadwiseSync"').where(p=>p.file.frontmatter?.author=='nickwignall.com')
 dv.view("rw-inbox-view", byAuthor);
 ```
-~~~
-
-
-
-
-
-
-
-

--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,14 @@ OnProcessAddTags: anki-added
 ---
 ```
 
+### Filtering from Quote Display
+
+We need tag information in our quotes for processing purposes, but you might not want to see them. You can filter any content from the highlight display by specifying the `FilterFromQuoteDisplay` parameter. This takes a string, such as `'{Tagged: .*}'`, and converts it into a regular expression that will be used for filtering text shown in the dataview results.
+
+### Filtering from Clipboard Copy
+
+You might want to see tag information when processing quotes, but not when copying quotes. In that case, you can specify the `FilterFromClipboardCopy` parameter. This takes a string, such as `'{Tagged: .*}'`, and converts it into a regular expression that will be used for filtering text that is copied to clipboard.
+
 ### Querying for specific information
 
 The `rw-inbox-view` accepts an optional parameter, a `dv.pages` object. This object can be used to provide a refined set of pages based on a JavaScript Dataview query. 

--- a/rw-inbox/rw-inbox-config.md
+++ b/rw-inbox/rw-inbox-config.md
@@ -39,15 +39,7 @@ ReadwisePathLogProcessed:: rw-inbox-log-processed
 
 **Note:** for this to work, tags must be included in the block, please see the Readme for more information.
 
-Examples:
-```
-FilterTags:: concept-todo
-FilterTags:: [concept-todo, todo, extract]
-```
-
 ## FilterTagsToExclude
 **Definition:** Exclude highlight blocks that contain the specified tag(s). Tag names should specified without the hash mark (\#concept-todo => concept-todo). You can specify either a single value or a list of values. When a list is used, the include logic is a logical NOR - a highlight featuring any of the specify tags will be excluded.
 
 **Note:** for this to work, tags must be included in the block, please see the Readme for more information.
-
-FilterTagsToExclude::[anki-added, concept-processed]

--- a/rw-inbox/rw-inbox-config.md
+++ b/rw-inbox/rw-inbox-config.md
@@ -9,8 +9,8 @@ This configuration file uses inline fields. An inline field is made up of 3 elem
 Example
 `FieldName:: Field value`
 
-
 # Configuration settings
+
 ## LimitHighlightCount
 **Definition**: The number of highlights to display. Can be overridden in a pages frontmatter.
 
@@ -25,3 +25,19 @@ SortDateAscending:: true
 **Definition**: Name of log file for processed highlights.
 
 ReadwisePathLogProcessed:: rw-inbox-log-processed
+
+## FilterTags
+**Definition:** Only show highlight blocks that contain the specified tag. The option should be specified without the hash mark (\#concept-todo => concept-todo)  **Note well:** for this to work, tags must be included in the block. 
+
+==TODO: have the option to filter in this file?==
+==TODO: turn into a list?==
+
+==custom==
+Only show highlight blocks containing the specified tag
+Tag should be specified WITHOUT the name (\#concept-todo => concept-todo)
+by default, this will not be set
+
+## FilterTagsToExclude
+==custom== list of tags to exclude
+
+FilterTagsToExclude::[anki-added, concept-processed]

--- a/rw-inbox/rw-inbox-config.md
+++ b/rw-inbox/rw-inbox-config.md
@@ -1,43 +1,53 @@
-# Instructions
-This is the configuration file for the Readwise Inbox tool. It contains the default values for this tool in your vault. Most of these settings can be overridden with frontmatter on a page where this view is embedded. See the [[readme.md]] file for more info.
+# Readwise Inbox Configuration
 
-This configuration file uses inline fields. An inline field is made up of 3 elements:
+This is the configuration file for the Readwise Inbox tool. It contains the default values for all views in your vault. These settings can also be overridden in individual files, whether in the YAML front-matter or in an inline dataview tag.
+
+This configuration file uses inline fields to set defaults. An inline field is made up of 3 elements:
 - The Field name
 - Two colons 
 - the value
 
-Example
-`FieldName:: Field value`
+
+Example:
+```
+FieldName:: Field value
+```
 
 # Configuration settings
 
 ## LimitHighlightCount
-**Definition**: The number of highlights to display. Can be overridden in a pages frontmatter.
+
+**Definition**: The number of highlights to display. Defaults to 20 if unspecified, has a maximum value of 1000.
 
 LimitHighlightCount:: 20
 
 ## SortDateAscending
-**Definition**: true will sort ascending, false will sort descending. Can be overridden in a pages frontmatter.
+
+**Definition**: true will sort ascending, false will sort descending. 
 
 SortDateAscending:: true
 
 ## ReadwisePathLogProcessed
+
 **Definition**: Name of log file for processed highlights.
 
 ReadwisePathLogProcessed:: rw-inbox-log-processed
 
 ## FilterTags
-**Definition:** Only show highlight blocks that contain the specified tag. The option should be specified without the hash mark (\#concept-todo => concept-todo)  **Note well:** for this to work, tags must be included in the block. 
 
-==TODO: have the option to filter in this file?==
-==TODO: turn into a list?==
+**Definition:** Only show highlight blocks that contain the specified tag(s). Tag names should specified without the hash mark (\#concept-todo => concept-todo). You can specify either a single value or a list of values. When a list is used, the include logic is a logical OR - a highlight featuring any of the specify tags will be included.
 
-==custom==
-Only show highlight blocks containing the specified tag
-Tag should be specified WITHOUT the name (\#concept-todo => concept-todo)
-by default, this will not be set
+**Note:** for this to work, tags must be included in the block, please see the Readme for more information.
+
+Examples:
+```
+FilterTags:: concept-todo
+FilterTags:: [concept-todo, todo, extract]
+```
 
 ## FilterTagsToExclude
-==custom== list of tags to exclude
+**Definition:** Exclude highlight blocks that contain the specified tag(s). Tag names should specified without the hash mark (\#concept-todo => concept-todo). You can specify either a single value or a list of values. When a list is used, the include logic is a logical NOR - a highlight featuring any of the specify tags will be excluded.
+
+**Note:** for this to work, tags must be included in the block, please see the Readme for more information.
 
 FilterTagsToExclude::[anki-added, concept-processed]

--- a/rw-inbox/rw-inbox-config.md
+++ b/rw-inbox/rw-inbox-config.md
@@ -43,3 +43,13 @@ ReadwisePathLogProcessed:: rw-inbox-log-processed
 **Definition:** Exclude highlight blocks that contain the specified tag(s). Tag names should specified without the hash mark (\#concept-todo => concept-todo). You can specify either a single value or a list of values. When a list is used, the include logic is a logical NOR - a highlight featuring any of the specify tags will be excluded.
 
 **Note:** for this to work, tags must be included in the block, please see the Readme for more information.
+
+## FilterFromQuoteDisplay
+**Definition:** A regex string representing text to filter out of your highlights. This is useful for eliminating things like `{Tagged: #some-tags}` from your quotes before they are presented to you.
+
+This is specified as a string without regex markers, For example, `'{Tagged: .*}'`. 
+
+## FilterFromClipboardCopy
+**Definition:** A regex string representing text to filter out of your highlights when they are copied to clipboard. This is useful for eliminating things like `{Tagged: #some-tags}` from your quotes when you copy them to the clipboard.
+
+This is specified as a string without regex markers, For example, `'{Tagged: .*}'`. 

--- a/rw-inbox/rw-inbox-view/view.js
+++ b/rw-inbox/rw-inbox-view/view.js
@@ -1,53 +1,261 @@
 // Readwise Inbox 
 // More info: https://github.com/TfTHacker/obsidian-readwise-inbox
-// File version: 0.0.2
+// File version: 0.1.1
+
+// TODO: option to remove this block from processing display - {Tagged: #anki}
 
 ( async ()=>{
     const {createButton} = app.plugins.plugins["buttons"]
-    //Config file values
+
+    /********
+    * Files *
+    ********/
+
+    /// This is the file that will be used to specify (default) settings that apply to ALL queries
     const configFile = dv.page("rw-inbox-config")
-    let limitHighlightCount = configFile.hasOwnProperty("LimitHighlightCount") ? configFile.LimitHighlightCount : 20 //default to 20 highlights
-    limitHighlightCount = dv.current().LimitHighlightCount ? dv.current().LimitHighlightCount : limitHighlightCount // pull if limit from current page
-    limitHighlightCount = limitHighlightCount > 1000 ? 1000 : limitHighlightCount
-    let sortDateAscending = configFile.hasOwnProperty("SortDateAscending") ? Boolean(configFile.SortDateAscending) : true //default to true 
-    sortDateAscending = dv.current().hasOwnProperty("SortDateAscending") ? dv.current().SortDateAscending : sortDateAscending // pull if limit from current page
-    //Log file
+
+    /// Log file that is used to record the processed block IDs
     const lgName = configFile.ReadwisePathLogProcessed;
     const lgTFile = await app.vault.getMarkdownFiles().find(e=>e.basename===lgName);
     let log = (await app.vault.cachedRead(lgTFile)).split("\n")
-    //Table columns
-    const tableColumnNames = ["Block","","","","",""]
+
+    /************************
+    * Configuration Options *
+    ************************/
+
+    /*** Highlight Limit ***/
+    const limitHighlightCount = function(){
+        let val = configFile.hasOwnProperty("LimitHighlightCount") ? configFile.LimitHighlightCount : 20 //default to 20 highlights
+        val = dv.current().LimitHighlightCount ? dv.current().LimitHighlightCount : val // pull if limit from current page
+        val = val > 1000 ? 1000 : val
+        return val;
+    }();
+
+    /*** Filtering on Tags - Includes and Excludes ***/
+    const filterTags = function(){
+        let val = dv.current().FilterTags ? dv.current().FilterTags :
+            configFile.hasOwnProperty("FilterTags") ? configFile.FilterTags : '';
+
+        if(!Array.isArray(val))
+        {
+            val = [val];
+        }
+
+        return val;
+    }();
+
+    const filterTagsToExclude = function(){
+        let val = dv.current().FilterTagsToExclude ? dv.current().FilterTagsToExclude :
+            configFile.hasOwnProperty("FilterTagsToExclude") ? configFile.FilterTagsToExclude : '';
+
+        // We need to coerce single values into an array for consistent processing
+        if(!Array.isArray(val))
+        {
+            val = [val];
+        }
+
+        return val;
+    }();
+
+    /*** Processing Tags - Add and Remove ***/
+    const OnProcessRemoveTags = function(){
+        // Prefer specification in file, then specification in config, then a default
+        let val = dv.current().OnProcessRemoveTags ? dv.current().OnProcessRemoveTags :
+            configFile.hasOwnProperty("OnProcessRemoveTags") ? configFile.OnProcessRemoveTags : null;
+
+        // We need to coerce single values into an array for consistent processing
+        if(!Array.isArray(val))
+        {
+            val = [val];
+        }
+
+        return val;
+    }();
+
+    const OnProcessAddTags = function(){
+        let val = dv.current().OnProcessAddTags ? dv.current().OnProcessAddTags : configFile.hasOwnProperty("OnProcessAddTags") ? configFile.OnProcessAddTags : null;
+
+        // We need to coerce single values into an array for consistent processing
+        if(!Array.isArray(val))
+        {
+            val = [val];
+        }
+
+        return val;
+    }();
+
+    const sortDateAscending = function(){
+        let val = configFile.hasOwnProperty("SortDateAscending") ? Boolean(configFile.SortDateAscending) : true //default to true
+        val = dv.current().hasOwnProperty("SortDateAscending") ? dv.current().SortDateAscending : val // pull if limit from current page
+        return val;
+    }();
+
+    /************************
+    * Readwise API Requests *
+    ************************/
+
+    /// This header should be set for all Readwise API transactions,
+    /// otherwise you will get Error 401
+    const readwise_auth_header =
+    {
+        "Authorization": "Token " + app.plugins.plugins["readwise-official"].settings.token
+    }
+
+    /// This function retrieves the tags associated with the highlight.
+    /// This method is used to find the proper Readwise tag ID for use
+    /// with removeTagRequest()
+    async function getHighlightTagsRequest(rw_highlight_id)
+    {
+        const highlight_tags = await requestUrl(
+        {
+            url: 'https://readwise.io/api/v2/highlights/' + rw_highlight_id + '/tags',
+            contentType: 'application/json',
+            headers: readwise_auth_header
+        })
+
+        console.log("Highlight Tags for " + rw_highlight_id + ": " + JSON.stringify(highlight_tags.json));
+
+        return highlight_tags.json
+    }
+
+    /// Send a tag delete request to the Readwise API
+    /// This endpoint does not take any data, so you can
+    /// only delete one tag_id per request.
+    async function removeTagRequest(rw_highlight_id, tag_id)
+    {
+        const response = await request(
+        {
+            url: 'https://readwise.io/api/v2/highlights/' + rw_highlight_id + '/tags/' + tag_id,
+            method: 'DELETE',
+            contentType: 'application/json',
+            headers: readwise_auth_header
+        })
+    }
+
+    /// Send an "add tag" request to the Readwise API
+    /// This endpoint appears to only allow one tag to be specified
+    /// in the payload at a time.
+    async function addTagRequest(rw_highlight_id, tag_name)
+    {
+        const response = await request(
+        {
+            url: 'https://readwise.io/api/v2/highlights/' + rw_highlight_id + '/tags',
+            method: 'POST',
+            contentType: 'application/json',
+            headers: readwise_auth_header,
+            body: JSON.stringify({"name": tag_name})
+        })
+    }
+
+    /// This function removes the specified tags (if set) from the target highlight.
+    /// tags_to_remove can be specified as a single value tag name,
+    /// or it can be an array of tag names.
+    ///
+    /// To remove the tag, we need to perform a lookup on the highlight so we
+    /// can get the numerical tag ID associated with that name.
+    async function removeHighlightTags(rw_highlight_id, tags_to_remove)
+    {
+        tags_for_highlight = await getHighlightTagsRequest(rw_highlight_id);
+
+        // We can only remove tags if there are some to begin with
+        if (tags_for_highlight.count)
+        {
+            // The tag API only allows single-tag removal,
+            // so we need to iterate over the list and remove one at a time
+            for(var remove_tag_name of tags_to_remove)
+            {
+                let id_to_remove = null;
+
+                // We'll look up the tag name in the highlight return value
+                // to find the proper ID for use with the API
+                for(var tag of tags_for_highlight.results)
+                {
+                    // If we've found a match, remove
+                    if(tag.name == remove_tag_name)
+                    {
+                        id_to_remove = tag.id;
+                        break;
+                    }
+                }
+
+                if(id_to_remove)
+                {
+                    removeTagRequest(rw_highlight_id, id_to_remove);
+                }
+                else
+                {
+                    console.warn("[Readwise Tag Remove] Highlight ID " + rw_highlight_id + " does not contain the tag " + tag_name);
+                }
+            }
+
+        }
+        else
+        {
+            console.warn("[Readwise Tag Remove] highlight id " + rw_highlight_id + " has no tags");
+        }
+    }
+
+    /********************
+    * Button Processing *
+    ********************/
 
     function bttnUpdate(row) {
-        return createButton({app, el: dv.container, 
-            args:          { name: "X", class: "rwbttn" }, 
-            clickOverride: { click: (rowid)=>{
-                app.vault.append(lgTFile,`\n${rowid}`)
+        return createButton({app, el: dv.container,
+            args:          { name: "X", class: "rwbttn" },
+            clickOverride: { click: async (rowid)=> {
+                // First, we need to note that this block has been processed
+                app.vault.append(lgTFile,`${rowid}\n`)
+
+                // Next, we need to handle any tags we want to modify
+
+                if(OnProcessRemoveTags)
+                {
+                    console.log("Attempting to remove tag(s): " + OnProcessRemoveTags)
+                    removeHighlightTags(rowid, OnProcessRemoveTags);
+                }
+
+                if(OnProcessAddTags)
+                {
+                    console.log("Attempting to add tag(s): " + OnProcessAddTags)
+
+                    for(var tag of OnProcessAddTags)
+                    {
+                        addTagRequest(rowid, tag);
+                    }
+                }
+
             }, params: [row.id] }
         })
     }
-    
+
     function bttnCopyBlockRef(row, caption, copyAsAlias = false, ifAliasIncludeText = false) {
-        return createButton({app, el: dv.container, 
-            args:          { name: caption, class: "rwbttn" }, 
+        return createButton({app, el: dv.container,
+            args:          { name: caption, class: "rwbttn" },
             clickOverride: {
                 click: (blockId, file)=>{
                     let ref = ""
                     if(copyAsAlias) {
                         ref = `[[${dv.io.normalize(file.name)}#^${blockId}|*]]`
-                        if(ifAliasIncludeText) 
+                        if(ifAliasIncludeText)
                             ref += row.block + ref;
-                    } else { 
+                    } else {
                         ref = `![[${dv.io.normalize(file.name)}#^${blockId}]]`
                     }
                     navigator.clipboard.writeText( ref );
                     new Notice(`Copied to clipboard:\n${ref}`,5000)
-                }, 
+                },
                 params: [row.realId, row.file, row.block]
             }
         })
     }
-    
+
+    /***************
+    * Data Display *
+    ***************/
+
+    //Table columns
+    const tableColumnNames = ["Block","","","","",""]
+
     async function getData() {
         let rwBlocks = [];
         const fileList = input ? input : await dv.pages('"' + app.plugins.plugins["readwise-official"].settings.readwiseDir +'"')
@@ -55,15 +263,34 @@
             const tFile = app.vault.getAbstractFileByPath(file.file.path)
             const contents = await app.vault.cachedRead(tFile)
             const cachedContents = app.metadataCache.getCache(file.file.path);
-            if(cachedContents.blocks) { 
+            if(cachedContents.blocks) {
                 Object.values(cachedContents.blocks).forEach(b=>{
                     const ID = b.id.replace(/\D/g,'');
                     if(!log.includes(ID)) {
+                        // This translates from the Obsidian block format to the output format.
+                        // The `block` field contains the actual string data we want to see.
                         let output = {
                             id: ID, realId: b.id, file: tFile,
                             block: contents.substring(b.position.start.offset, b.position.end.offset).replace("- ","").replace(" ^" + b.id,"")
                         };
-                        rwBlocks.push(output)
+
+                        // First, check if we are filtering for a tag.
+                        // If not, we'll enter
+                        // if so, we'll only enter if a desired tag is found (logical OR)
+                        if(!filterTags || filterTags.find(test => output.block.includes('#' + test)))
+                        {
+                            // next, we need to audit the exclude list
+                            // If it's not set, we'll enter
+                            // If it is set, we'll only enter if no excludes are found
+                            //
+                            // Alternate single tag version: output.block.includes('#' + filterTagsToExclude)
+                            if(!filterTagsToExclude || !filterTagsToExclude.find(test => output.block.includes('#' + test)))
+                            {
+                                // TODO: strip out the [Tagged] block. Perhaps, too, we just allow the user
+                                // to configure the regex
+                                rwBlocks.push(output)
+                            }
+                        }
                     }
                 })
             }

--- a/rw-inbox/rw-inbox-view/view.js
+++ b/rw-inbox/rw-inbox-view/view.js
@@ -34,9 +34,9 @@
     /*** Filtering on Tags - Includes and Excludes ***/
     const filterTags = function(){
         let val = dv.current().FilterTags ? dv.current().FilterTags :
-            configFile.hasOwnProperty("FilterTags") ? configFile.FilterTags : '';
+            configFile.hasOwnProperty("FilterTags") ? configFile.FilterTags : null;
 
-        if(!Array.isArray(val))
+        if(val && !Array.isArray(val))
         {
             val = [val];
         }
@@ -46,10 +46,10 @@
 
     const filterTagsToExclude = function(){
         let val = dv.current().FilterTagsToExclude ? dv.current().FilterTagsToExclude :
-            configFile.hasOwnProperty("FilterTagsToExclude") ? configFile.FilterTagsToExclude : '';
+            configFile.hasOwnProperty("FilterTagsToExclude") ? configFile.FilterTagsToExclude : null;
 
         // We need to coerce single values into an array for consistent processing
-        if(!Array.isArray(val))
+        if(val && !Array.isArray(val))
         {
             val = [val];
         }
@@ -64,7 +64,7 @@
             configFile.hasOwnProperty("OnProcessRemoveTags") ? configFile.OnProcessRemoveTags : null;
 
         // We need to coerce single values into an array for consistent processing
-        if(!Array.isArray(val))
+        if(val && !Array.isArray(val))
         {
             val = [val];
         }
@@ -76,7 +76,7 @@
         let val = dv.current().OnProcessAddTags ? dv.current().OnProcessAddTags : configFile.hasOwnProperty("OnProcessAddTags") ? configFile.OnProcessAddTags : null;
 
         // We need to coerce single values into an array for consistent processing
-        if(!Array.isArray(val))
+        if(val && !Array.isArray(val))
         {
             val = [val];
         }

--- a/rw-inbox/rw-inbox-view/view.js
+++ b/rw-inbox/rw-inbox-view/view.js
@@ -90,6 +90,37 @@
         return val;
     }();
 
+    /*** Filtering Content Within Quotes ***/
+    const FilterFromQuoteDisplay = function(){
+        // Prefer specification in file, then specification in config, then a default
+        let regex_string = dv.current().FilterFromQuoteDisplay ? dv.current().FilterFromQuoteDisplay :
+            configFile.hasOwnProperty("FilterFromQuoteDisplay") ? configFile.FilterFromQuoteDisplay : null;
+
+        if(regex_string)
+        {
+            return new RegExp(regex_string, 'g')
+        }
+        else
+        {
+            return null;
+        }
+    }();
+
+    const FilterFromClipboardCopy = function(){
+        // Prefer specification in file, then specification in config, then a default
+        let regex_string = dv.current().FilterFromClipboardCopy ? dv.current().FilterFromClipboardCopy :
+            configFile.hasOwnProperty("FilterFromClipboardCopy") ? configFile.FilterFromClipboardCopy : null;
+
+        if(regex_string)
+        {
+            return new RegExp(regex_string, 'g')
+        }
+        else
+        {
+            return null;
+        }
+    }();
+
     /************************
     * Readwise API Requests *
     ************************/
@@ -240,6 +271,11 @@
                         {
                             ref = `[[${filename}#^${blockId}]]\n`;
                             ref += row.block;
+
+                            if(FilterFromClipboardCopy)
+                            {
+                                ref = ref.replace(FilterFromClipboardCopy, '');
+                            }
                         }
                         else {
                             ref = `[[${filename}#^${blockId}]]`
@@ -292,8 +328,10 @@
                             // Alternate single tag version: output.block.includes('#' + filterTagsToExclude)
                             if(!filterTagsToExclude || !filterTagsToExclude.find(test => output.block.includes('#' + test)))
                             {
-                                // TODO: strip out the [Tagged] block. Perhaps, too, we just allow the user
-                                // to configure the regex
+                                if(FilterFromQuoteDisplay)
+                                {
+                                    output.block = output.block.replace(FilterFromQuoteDisplay, '');
+                                }
                                 rwBlocks.push(output)
                             }
                         }

--- a/rw-inbox/rw-inbox-view/view.js
+++ b/rw-inbox/rw-inbox-view/view.js
@@ -234,12 +234,18 @@
             clickOverride: {
                 click: (blockId, file)=>{
                     let ref = ""
+                    let filename = dv.io.normalize(file.name).replace('.md', '')
                     if(copyAsAlias) {
-                        ref = `[[${dv.io.normalize(file.name)}#^${blockId}|*]]`
                         if(ifAliasIncludeText)
-                            ref += row.block + ref;
+                        {
+                            ref = `[[${filename}#^${blockId}]]\n`;
+                            ref += row.block;
+                        }
+                        else {
+                            ref = `[[${filename}#^${blockId}]]`
+                        }
                     } else {
-                        ref = `![[${dv.io.normalize(file.name)}#^${blockId}]]`
+                        ref = `![[${filename}#^${blockId}]]`
                     }
                     navigator.clipboard.writeText( ref );
                     new Notice(`Copied to clipboard:\n${ref}`,5000)


### PR DESCRIPTION
As mentioned on Discord, here are the changes I made in my workflow to:

- Support filtering highlights by tags (both to include and exclude individual highlights)
- Support removing and adding tags on the Readwise server when processing notes with "X"
- README updates (some general tidying improvements, others to explain the new workflow requirements)
- New configuration options + documentation for those options.

I really appreciate that you put this together. I have been neglecting my highlight processing since I have needed to do it on the website. Doing it directly in Obsidian makes it so much easier for me to work with the highlights.